### PR TITLE
chore: update .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 shamefully-hoist=true
-strict-peer-dependencies=false


### PR DESCRIPTION
The default value of the `strict-peer-dependencies` attribute is `false`

[Pnpm Configuration](https://pnpm.io/npmrc#strict-peer-dependencies)