### PR TITLE
fix: error occurred when using `definePage`

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,18 +26,18 @@ export default defineConfig({
   },
 
   plugins: [
+    // https://github.com/posva/unplugin-vue-router
+    VueRouter({
+      extensions: ['.vue', '.md'],
+      dts: 'src/typed-router.d.ts',
+    }),
+
     VueMacros({
       plugins: {
         vue: Vue({
           include: [/\.vue$/, /\.md$/],
         }),
       },
-    }),
-
-    // https://github.com/posva/unplugin-vue-router
-    VueRouter({
-      extensions: ['.vue', '.md'],
-      dts: 'src/typed-router.d.ts',
     }),
 
     // https://github.com/JohnCampionJr/vite-plugin-vue-layouts


### PR DESCRIPTION
### Description

Modified the registration location of the `unplugin-vue-router` plugin 

It needs to be registered before 'vue'

![image](https://github.com/user-attachments/assets/200e6318-ab89-447a-9b67-c39c08e98618)

### Linked Issues

fixes #551 

